### PR TITLE
Warm up export zip rq

### DIFF
--- a/templates/applications/export.html
+++ b/templates/applications/export.html
@@ -35,8 +35,8 @@
                 {% endif %}
                 <p><span class="label label-danger"><i class="icon-bullhorn"></i> IMPORTANT</span> This export option stills in beta mode and may fail in the CKAN server. If you get an error, please send an e-mail to info@pybossa.com</p>
                 {% if current_user.ckan_api %}
-                <a id="ckan_task" href="{{url_for('app.export_to', short_name=app.short_name, type='task', format='ckan')}}" rel="nofollow" class="btn btn-large" download>{{_('Tasks')}}</a>
-                <a id="ckan_task_run" href="{{url_for('app.export_to', short_name=app.short_name, type='task_run', format='ckan')}}" rel="nofollow" class="btn btn-large" download>{{_('Task Runs')}}</a>
+                <a id="ckan_task" href="{{url_for('app.export_to', short_name=app.short_name, type='task', format='ckan')}}" rel="nofollow" class="btn btn-large">{{_('Tasks')}}</a>
+                <a id="ckan_task_run" href="{{url_for('app.export_to', short_name=app.short_name, type='task_run', format='ckan')}}" rel="nofollow" class="btn btn-large">{{_('Task Runs')}}</a>
                 {% else %}
                 <p id="ckan_warning">You don't have a Datahub.io API key in your {{BRAND}} account. Please,  <a href="http://datahub.io/user/register">create an account</a> and copy/paste the API key in your profile in order to use this exporter.</p>
                 {% endif %}

--- a/templates/applications/tasks.html
+++ b/templates/applications/tasks.html
@@ -24,7 +24,7 @@
                     <div id="export_tasks" class="span6 well">
                         <h2><i class="icon-download"></i> {{_('Export Tasks')}}</h2>
                         <p>{{_('Export tasks to JSON, CSV or a CKAN server')}}</p>
-                        <a href="{{url_for('app.export_to', short_name=app.short_name)}}" rel="nofollow" class="btn btn-primary" download>{{_('Export')}} <i class="icon-chevron-right"></i></a>
+                        <a href="{{url_for('app.export_to', short_name=app.short_name)}}" rel="nofollow" class="btn btn-primary">{{_('Export')}} <i class="icon-chevron-right"></i></a>
                     </div>
                 </div>
                 <div class="row-fluid">
@@ -60,7 +60,7 @@
                     <div id="export_tasks" class="span6 well">
                         <h2><i class="icon-download"></i> {{_('Export Tasks')}}</h2>
                         <p>{{_('Export tasks to JSON, CSV or a CKAN server')}}</p>
-                        <a href="{{url_for('app.export_to', short_name=app.short_name)}}" rel="nofollow" class="btn btn-primary" download>{{_('Export')}} <i class="icon-chevron-right"></i></a>
+                        <a href="{{url_for('app.export_to', short_name=app.short_name)}}" rel="nofollow" class="btn btn-primary">{{_('Export')}} <i class="icon-chevron-right"></i></a>
                     </div>
                 </div>
                 {% endif %}


### PR DESCRIPTION
Will give fewer error messages in Chrome and FF:
"Resource interpreted as Document but transferred with MIME type application/zip"

References:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
https://html.spec.whatwg.org/multipage/semantics.html#downloading-resources
